### PR TITLE
bugfix/#5_webpack-failure-not-stopping-bundle

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,7 @@ namespace DocsEngine {
 				} ) );
 
 				if( error ) reject( error );
+				if( stats.hasErrors() ) reject( new Error(stats.toString("errors-only")));
 				else resolve();
 			} );
 		} )


### PR DESCRIPTION
- Resolved #5 

Webpack now prints all the errors and sends a rejects the promise stopping the bundle execution.