### PR TITLE
bugfix/#17_render-overloaded-methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,21 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- [#17](https://github.com/CarbonLDP/carbonldp-ts-docs-engine/issues/17) Overloaded methods now render with all their signatures
+
+## [1.0.1] (2019-11-26)
+
+### Fixed
+
+- [#12](https://github.com/CarbonLDP/carbonldp-ts-docs-engine/issues/12) Fix asset loading when deployed in gh-pages
+
+## [1.0.0] (2019-11-04)
+
 - First release
 
-[Unreleased]: https://github.com/CarbonLDP/sparqler/compare/5886818...HEAD
+[Unreleased]: https://github.com/CarbonLDP/sparqler/compare/v1.0.1...HEAD
+
+[1.0.1]: https://github.com/CarbonLDP/carbonldp-ts-docs-engine/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/CarbonLDP/carbonldp-ts-docs-engine/compare/5886818...v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - First release
 
-[Unreleased]: https://github.com/CarbonLDP/sparqler/compare/v1.0.1...HEAD
+[Unreleased]: https://github.com/CarbonLDP/carbonldp-ts-docs-engine/compare/v1.0.1...HEAD
 
 [1.0.1]: https://github.com/CarbonLDP/carbonldp-ts-docs-engine/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/CarbonLDP/carbonldp-ts-docs-engine/compare/5886818...v1.0.0

--- a/src/templates/macros/renderMember.macro.njk
+++ b/src/templates/macros/renderMember.macro.njk
@@ -20,7 +20,7 @@
         {% set title = 'Static Methods' if isStatic else 'Methods' %}
         <h3 class="doc-content__title">{{ title }}</h3>
         {% for member in members %}
-            {% set signatures = [ member ] if doc.docType === 'interface' or member.overloads.length === 0 else [] %}
+            {% set signatures = [ member ] %}
             {% set signatures = signatures.concat( member.overloads ) %}
             {% for signature in signatures %}
                 {{ memberCode.method( signature ) }}


### PR DESCRIPTION
Resolved #17.

- Removed conditions that were used in the previous docs engine, now that the code was refactored.
- Overloaded methods now render multiple times in the documentation